### PR TITLE
trim whitespace with lodash

### DIFF
--- a/lib/clause.js
+++ b/lib/clause.js
@@ -5,6 +5,7 @@ const Operator = require('./operator');
 const Range = require('./range');
 const Target = require('./target');
 
+const _ = require('lodash');
 
 /**
  * @class ClauseBase
@@ -457,8 +458,9 @@ class Clause {
 
   /** @private */
   _literal(value) {
-    Clause._assertLiteral(value);
-    return this._object(value);
+    const val = typeof value === 'string' ? _.trim(value) : value;
+    Clause._assertLiteral(val);
+    return this._object(val);
   }
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Dynamic filter expression parsing, formatting, and abstractions for web APIs.",
   "version": "1.3.0",
   "dependencies": {
-    "elv": "^2.0.0"
+    "elv": "^2.0.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "spleen",
-  "longName": "spleen",
-  "description": "Dynamic filter expression parsing, formatting, and abstractions for web APIs.",
-  "version": "1.3.0",
+  "name": "@polis-politics/spleen",
+  "longName": "@polis-politics/spleen",
+  "description": "Polis' Dynamic filter expression parsing, formatting, and abstractions for web APIs, forked from spleed-node npm package",
+  "version": "1.0.0",
   "dependencies": {
     "elv": "^2.0.0",
     "lodash": "^4.17.15"
@@ -35,7 +35,7 @@
   "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/dsfields/spleen-node"
+    "url": "https://github.com/PolisPolitics/spleen-node"
   },
   "scripts": {
     "lint": "eslint ./*",

--- a/test/unit/filter.test.js
+++ b/test/unit/filter.test.js
@@ -1328,12 +1328,25 @@ describe('Filter', () => {
       .eq()
       .literal(true);
 
+    const clauseD = Clause
+      .target('/bar')
+      .neq()
+      .literal(' a? ');
+
     it('should stringify clause', () => {
       const result = Filter
         .where(clauseA)
         .toString();
 
       assert.strictEqual(result, '/foo gt 42');
+    });
+
+    it('should trim spaces and stringify clause', () => {
+      const result = Filter
+        .where(clauseD)
+        .toString();
+
+      assert.strictEqual(result, '/bar neq "a?"');
     });
 
     it('should stringify anded clauses', () => {

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -173,6 +173,13 @@ describe('Parser', () => {
       assert.strictEqual(filter.statements[0].value.object, 42);
     });
 
+    it('should not parse Uuid that is not in quotes', () => {
+      const parser = new Parser('/foo/bar eq 184348ca-60db-4d86-9e99-40cc8245c0db');
+      const result = parser.parse();
+      assert.isFalse(result.success);
+      assert.instanceOf(result.error, errors.ParserError);
+    });
+
     it('should parse Boolean object for eq', () => {
       const parser = new Parser('/foo eq false');
       const filter = parser.parse().value;


### PR DESCRIPTION
If you send a filter to spleen that has an extra white space at the end of the filter, the result from the API is to return ALL records.

filter=/data/contactId eq "184348ca-60db-4d86-9e99-40cc8245c0db"%20 <- Extra space

We are now trimming this