### PR TITLE
Allowing silent errors to occur when value is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,9 @@ const Target = require('./target');
 
 
 const parse = function (value) {
+  if (value === undefined) {
+    return '';
+  }
   const parser = new Parser(value);
   return parser.parse();
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,7 +12,9 @@ const Token = require('./token');
 class Parser {
 
   constructor(value) {
-    this.tokenizer = new Tokenizer(value);
+    if (value !== undefined) {
+      this.tokenizer = new Tokenizer(value);
+    }
   }
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@polis-politics/spleen",
   "longName": "@polis-politics/spleen",
   "description": "Polis' Dynamic filter expression parsing, formatting, and abstractions for web APIs, forked from spleed-node npm package",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "dependencies": {
     "elv": "^2.0.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Currently, spleen is catching too many errors. When value is undefined, we want to stop parsing the value. Only when there is a value, do we want to continue the chain of events